### PR TITLE
[9.X]Add attributesToDatabaseArray() function to HasAttributes trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -206,7 +206,7 @@ trait HasAttributes
     }
 
     /**
-     * Convert the model's attributes to an databse result array.
+     * Convert the model's attributes to a database result array.
      *
      * @return array
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -204,6 +204,26 @@ trait HasAttributes
 
         return $attributes;
     }
+    
+    /**
+     * Convert the model's attributes to an databse result array.
+     *
+     * @return array
+     */
+    public function attributesToDatabaseArray()
+    {
+        $attributes = $this->getRawOriginal();
+
+        // As database store boolean value as "0" or "1", so we convert boolean value
+        // to "0" or "1" 
+        foreach ($attributes as $key => $value) {
+            if (is_bool($value)) {
+                $attributes[$key] = $value ? "1" : "0";
+            }
+        }
+
+        return $attributes;
+    }
 
     /**
      * Add the date attributes to the attributes array.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -204,7 +204,7 @@ trait HasAttributes
 
         return $attributes;
     }
-    
+
     /**
      * Convert the model's attributes to an databse result array.
      *
@@ -215,10 +215,10 @@ trait HasAttributes
         $attributes = $this->getRawOriginal();
 
         // As database store boolean value as "0" or "1", so we convert boolean value
-        // to "0" or "1" 
+        // to "0" or "1"
         foreach ($attributes as $key => $value) {
             if (is_bool($value)) {
-                $attributes[$key] = $value ? "1" : "0";
+                $attributes[$key] = $value ? '1' : '0';
             }
         }
 


### PR DESCRIPTION
When testing model value updated or not using assertDatabaseHas(), if model has boolean attributes would make test failed due to database store boolean value as "0", "1", while model casts the attributes to be boolean.

For example:

```
// Model
class User extends Model
{
    protected $casts = [
        'bool_col' => 'boolean',
    ];
}

// Factory
class UserFactory extends Factory
{
    public function definition()
    {
        return [
            'bool_col' => "1", // true
        ];
    }
}

// Test
class UserTest extends TestCase
{
    public function test_user_can_be_updated()
    {
        $user = User::factory()->create();

        $response = $this->put('/users/' . $user->id, $user->attributesToArray());

        $response->assertSessionHasNoErrors();
        $this->assertDatabaseHas('users', $user->attributesToArray()); // Failed here
    }
}

// Error message
Failed asserting that a row in the table [users] matches the attributes {
    "bool_col": false,
    "id": 1
}.

Found similar results: [
    {
        "bool_col": "0",
        "id": 1
    }
]
```

Improvement of attributesToDatabaseArray() function: 
```
// Output
{
    "bool_col": "0",
    "id": 1
}

// Output is the same as the retrieved records.
```

P.S.
I made this change when I use sqlite as test database, this may no be worked when using other database such as MongoDB. Therefore, this may need further improvements.
